### PR TITLE
added sample urls list to backend/

### DIFF
--- a/backend/SampleListOfUrls.txt
+++ b/backend/SampleListOfUrls.txt
@@ -1,0 +1,11 @@
+https://countingup.com
+https://www.bbc.co.uk
+https://stackoverflow.com
+https://www.apple.com/uk/
+https://twitter.com
+https://www.hashicorp.com
+https://www.gov.uk
+https://www.docker.com
+https://beta.companieshouse.gov.uk
+https://aws.amazon.com
+https://www.gov.uk/doesnotexist


### PR DESCRIPTION
The URL list isn't included in the pdf instructions so let's include it in the repo. Added to `backend/` because it's needed in that exercise