### PR TITLE
Removed rendering test, added file reading example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.idea

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,9 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "./App";
+import data from "./out.json";
 
-it("renders without crashing", () => {
-  const div = document.createElement("div");
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+it("should read data", () => {
+  expect(data).toHaveLength(11);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import "./App.css";
 import Table from "./Table";
+import data from "./out.json";
 
 const App = () => {
+  console.log(data);
+
   return (
     <div className="App">
       <h1>Countingup</h1>


### PR DESCRIPTION
The existing auto-generated rendering test is a little misleading. Happy for a candidate to extend/write such tests but it's not really what we're after.

Also providing an example of how to import a JSON file, so we don't have to spend too much time on that particular issue. It's trivial thanks to a webpack plugin provided by create-react-app - so isn't particuarly easy to search for.