### PR TITLE
Add .editorconfig to configure editor settings based on current formatting

### DIFF
--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -1,0 +1,6 @@
+[*.{ts,tsx,js,jsx,json}]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
We applied prettier to the existing skeleton with an indent size of 2.
A lot of people have indent size of 4 and then spend time messing with formatting.

.editorconfig works in loads of IDEs (though unfortunately not VSCode out-of-the-box), so setting indent size to 2 here will reduce some friction.